### PR TITLE
Singularity Set Data Fix

### DIFF
--- a/cli/olaf/src/olaf/core/sandbox_management.py
+++ b/cli/olaf/src/olaf/core/sandbox_management.py
@@ -58,13 +58,12 @@ def init_singularity_exec(script_dir: str, sanbox_data_path, subprocess, console
             self._binds: List[str] = []
             self._proc = None
 
-        def set_data(self, dataset: Path, resources: List[Tuple[Path, str]]):
-            self._binds = [
-                "--bind",
-                f"{dataset.resolve()}:{sanbox_data_path}",
-            ]
-            for host, cont in resources:
-                self._binds.extend(["--bind", f"{host.resolve()}:{cont}"])
+        def set_data(self, all_resources: List[Tuple[Path, str]]):
+                    """Configures all necessary bind mounts from a single list."""
+                    binds = []
+                    for host_path, container_path in all_resources:
+                        binds.extend(["--bind", f"{host_path.resolve()}:{container_path}"])
+                    self._binds = binds
 
         # ------------------------------------------------------------------
         # Container lifecycle


### PR DESCRIPTION
This pull request simplifies the way bind mounts are configured in the `SandboxManager` by consolidating resource handling into a single method. Instead of requiring separate dataset and resource arguments, all resources are now passed in a single list, making the code cleaner and easier to maintain.

Refactoring and simplification:

* Refactored the `set_data` method in `sandbox_management.py` to accept a single list of resource tuples, removing the need for a separate dataset argument and simplifying the bind mount setup logic.